### PR TITLE
sprint 55 lib sub version fixes JC-1694

### DIFF
--- a/openfood_env.py
+++ b/openfood_env.py
@@ -2,7 +2,7 @@ from dotenv import load_dotenv, find_dotenv
 import os, requests
 load_dotenv(find_dotenv(), verbose=True)
 
-LIB_SUB_VERSION = 1
+LIB_SUB_VERSION = 55
 SKIP_BATCH_PROCESSING = 9000
 BATCH_PROCESSING = 5000
 NUM_10K = 10000


### PR DESCRIPTION
## Task
[JC-1694](https://thenewfork.atlassian.net/browse/JC-1694) adds incremental use of this variable for tracking version number of openfood lib used for various parts of the transaction sending.

## Related Task (Optional)
It is related to JC-1667 as well as [general housekeeping transcations](https://thenewfork.atlassian.net/issues/?jql=text%20~%20%22housekeeping%22)


## Summary
Bumps the version to 55, the last sprint number completed.

## Changes
This will increment every sprint.

