### PR TITLE
Feature/alphanumeric batches

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -1994,7 +1994,11 @@ def organization_send_batch_links3(batch_integrity, pon, bnfp):
         pon_as_satoshi = convert_alphanumeric_2d8dp(pon)
     else:
         pon_as_satoshi = dateToSatoshi(pon)
-    bnfp_as_satoshi = dateToSatoshi(bnfp)
+    print("bnfp is " + bnfp)
+    if not bnfp.isnumeric():
+        bnfp_as_satoshi = convert_alphanumeric_2d8dp(bnfp)
+    else:
+        bnfp_as_satoshi = dateToSatoshi(bnfp)
     pool_batch_wallet = organization_get_our_pool_batch_wallet()
     pool_po = organization_get_our_pool_po_wallet()
     customer_pool_wallet = organization_get_customer_po_wallet(CUSTOMER_RADDRESS)

--- a/openfood.py
+++ b/openfood.py
@@ -1203,11 +1203,16 @@ def gen_wallet_sha256hash(str):
     return gen_wallet_no_sign(hash256hex(str))
 
 
+def hash256hex(str):
+        return hashlib.sha256(str.encode()).hexdigest()
+
+
 def get_10digit_int_sha256(str):
     return int(hash256hex(str), base=16)
 
 
 def convert_alphanumeric_2d8dp(alphanumeric):
+    print("converting " + alphanumeric)
     return round(int(str(get_10digit_int_sha256(alphanumeric))[:10])/100000000, 10)
 
 
@@ -1984,9 +1989,9 @@ def deprecate_organization_send_batch_links2(batch_integrity, pon):
 
 # test skipped
 def organization_send_batch_links3(batch_integrity, pon, bnfp):
+    print("pon is " + pon)
     if not pon.isnumeric():
-        pon = convert_alphanumeric_2d8dp(pon)
-        pon_as_satoshi = dateToSatoshi(pon)
+        pon_as_satoshi = convert_alphanumeric_2d8dp(pon)
     else:
         pon_as_satoshi = dateToSatoshi(pon)
     bnfp_as_satoshi = dateToSatoshi(bnfp)

--- a/openfood.py
+++ b/openfood.py
@@ -1984,7 +1984,11 @@ def deprecate_organization_send_batch_links2(batch_integrity, pon):
 
 # test skipped
 def organization_send_batch_links3(batch_integrity, pon, bnfp):
-    pon_as_satoshi = dateToSatoshi(pon)
+    if not pon.isnumeric():
+        pon = convert_alphanumeric_2d8dp(pon)
+        pon_as_satoshi = dateToSatoshi(pon)
+    else:
+        pon_as_satoshi = dateToSatoshi(pon)
     bnfp_as_satoshi = dateToSatoshi(bnfp)
     pool_batch_wallet = organization_get_our_pool_batch_wallet()
     pool_po = organization_get_our_pool_po_wallet()

--- a/openfood.py
+++ b/openfood.py
@@ -1199,6 +1199,18 @@ def gen_wallet(data, label='NoLabelOK', verbose=False):
     return new_wallet
 
 
+def gen_wallet_sha256hash(str):
+    return gen_wallet_no_sign(hash256hex(str))
+
+
+def get_10digit_int_sha256(str):
+    return int(hash256hex(str), base=16)
+
+
+def convert_alphanumeric_2d8dp(alphanumeric):
+    return round(int(str(get_10digit_int_sha256(alphanumeric))[:10])/100000000, 10)
+
+
 def getOfflineWalletByName(name):
     obj = {
         "name": name
@@ -1480,6 +1492,8 @@ def sendToBatchPON_deprecated(batch_raddress, pon, integrity_id):
 
 
 def sendToBatchPON(batch_raddress, pon, integrity_id):
+    if not pon.isnumeric():
+        pon = convert_alphanumeric_2d8dp(pon)
     send_batch = sendToBatch(WALLET_PON, WALLET_PON_THRESHOLD_UTXO_VALUE, batch_raddress, pon, integrity_id)
     return send_batch # TXID
 

--- a/openfood.py
+++ b/openfood.py
@@ -195,6 +195,14 @@ def pogtid(po):
     return total
 
 
+def hex_to_base16_int(hex):
+    return int(hex, base=16)
+
+
+def hex_to_base_int(hex, base):
+    return int(hex, base=base)
+
+
 def sendtoaddress_wrapper(to_address, amount):
     send_amount = round(amount, 10)
     txid = rpclib.sendtoaddress(BATCHRPC, to_address, send_amount)

--- a/openfood.py
+++ b/openfood.py
@@ -1523,6 +1523,8 @@ def sendToBatchTIN_deprecated(batch_raddress, tin, integrity_id):
 
 
 def sendToBatchTIN(batch_raddress, tin, integrity_id):
+    if not tin.isnumeric():
+        tin = convert_alphanumeric_2d8dp(tin)
     send_batch = sendToBatch(WALLET_TIN, WALLET_TIN_THRESHOLD_UTXO_VALUE, batch_raddress, tin, integrity_id)
     return send_batch # TXID
 


### PR DESCRIPTION
## Task
[JC-1665](https://thenewfork.atlassian.net/browse/JC-1665)

## Summary
This PR fixes Dreher and Citrosuco requirements for PON, ANFP, BNFP to process alphanumeric (or any format data)

## Changes
Some checks for alphanumeric data and then process them through a hash function.

## Others (Optional)
This is a temporary solution, with collisions of 10 digit hashes possible with a large large large enough data set. The elegant solution for this is started in another branch and can be completed over the next several sprints.