### PR TITLE
[Main] explorer list in env blocknotify

### DIFF
--- a/openfood_env.py
+++ b/openfood_env.py
@@ -1,5 +1,6 @@
 from dotenv import load_dotenv, find_dotenv
 import os, requests
+import json
 load_dotenv(find_dotenv(), verbose=True)
 
 LIB_SUB_VERSION = 1
@@ -18,12 +19,15 @@ MULTI_4X = 4
 MULTI_5X = 5
 
 # Priority Explorer: first to last order
-EXPLORER_LIST = {
+EXPLORER_JSON = str(os.environ['EXPLORER_LIST'])
+EXPLORER_LIST = json.loads(EXPLORER_JSON)
+
+"""EXPLORER_LIST = {
     "ofcmvp.cakeshop": {
         "host": "ofcmvp.explorer.cakeshop.dev",
         "port": "443"
     }
-}
+}"""
 
 EXPLORER_URL = ""
 for explorer_name, explorer_data in EXPLORER_LIST.items():

--- a/openfood_env.py
+++ b/openfood_env.py
@@ -3,7 +3,7 @@ import os, requests
 import json
 load_dotenv(find_dotenv(), verbose=True)
 
-LIB_SUB_VERSION = 1
+LIB_SUB_VERSION = 56
 SKIP_BATCH_PROCESSING = 9000
 BATCH_PROCESSING = 5000
 NUM_10K = 10000

--- a/openfood_env.py
+++ b/openfood_env.py
@@ -22,13 +22,6 @@ MULTI_5X = 5
 EXPLORER_JSON = str(os.environ['EXPLORER_LIST'])
 EXPLORER_LIST = json.loads(EXPLORER_JSON)
 
-"""EXPLORER_LIST = {
-    "ofcmvp.cakeshop": {
-        "host": "ofcmvp.explorer.cakeshop.dev",
-        "port": "443"
-    }
-}"""
-
 EXPLORER_URL = ""
 for explorer_name, explorer_data in EXPLORER_LIST.items():
     if explorer_data["port"] == "443":


### PR DESCRIPTION
## Task
[JC-1690](https://thenewfork.atlassian.net/browse/JC-1690)

## Related Task (Optional)
[JC-1654](https://thenewfork.atlassian.net/browse/JC-1654)

## Summary
This PR is to move explorer list to env blocknotify

## Changes
Removing the explorer list and add explorer list to env as json, and then read the value using json library in openfood_env

## Others (Optional)
Need to added env variables in blocknotify:
EXPLORER_LIST={"ofcmvp.cakeshop": {"host": "ofcmvp.explorer.cakeshop.dev","port": "443"}}