### PR TITLE
Bugfix/organization noraddress url get vars

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -1748,8 +1748,8 @@ def get_batches():
     return batches
 
 
-def get_certificates_no_timestamp():
-    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_CERTIFICATE_NORADDRESS
+def get_certificates_no_timestamp(orgid):
+    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_CERTIFICATE_NORADDRESS + "?orgid=" + orgid
     try:
         res = requests.get(url)
     except Exception as e:
@@ -1758,8 +1758,8 @@ def get_certificates_no_timestamp():
     certs_no_addy = json.loads(res.text)
     return certs_no_addy
 
-def get_locations_no_timestamp():
-    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_LOCATION_NORADDRESS
+def get_locations_no_timestamp(orgid):
+    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_LOCATION_NORADDRESS + "?orgid=" + orgid
     try:
         res = requests.get(url)
     except Exception as e:

--- a/openfood.py
+++ b/openfood.py
@@ -1749,7 +1749,7 @@ def get_batches():
 
 
 def get_certificates_no_timestamp(orgid):
-    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_CERTIFICATE_NORADDRESS + "?orgid=" + orgid
+    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_CERTIFICATE_NORADDRESS + "?orgid=" + str(orgid)
     try:
         res = requests.get(url)
     except Exception as e:
@@ -1759,7 +1759,7 @@ def get_certificates_no_timestamp(orgid):
     return certs_no_addy
 
 def get_locations_no_timestamp(orgid):
-    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_LOCATION_NORADDRESS + "?orgid=" + orgid
+    url = openfood_API_BASE_URL + openfood_API_ORGANIZATION_LOCATION_NORADDRESS + "?orgid=" + str(orgid)
     try:
         res = requests.get(url)
     except Exception as e:


### PR DESCRIPTION
## Task
[JC-1718[(https://thenewfork.atlassian.net/browse/JC-1718)

## Summary
The script needs to get it's orgid from jc-api, then use that as a filter for a location without raddress search.

## Changes
Adds a query to jc-api, then passes the orgid to openfood lib function

