### PR TITLE
[MAIN] Fixing the mistake of passing pon instead of bnfp

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -1449,7 +1449,7 @@ def organization_send_batch_links3(batch_integrity, pon, bnfp):
             print("BNFP is alphanumeric.")
         bnfp_as_satoshi = convert_alphanumeric_2d8dp(bnfp)
     else:
-        bnfp_as_satoshi = dateToSatoshi(pon)
+        bnfp_as_satoshi = dateToSatoshi(bnfp)
         
     pool_batch_wallet = organization_get_our_pool_batch_wallet()
     pool_po = organization_get_our_pool_po_wallet()


### PR DESCRIPTION
## Task
[JC-1719](https://thenewfork.atlassian.net/browse/JC-1719)

## Related Task (Optional)
JC-1719 <--> [JC-1709](https://thenewfork.atlassian.net/browse/JC-1709)

## Summary
### JC-1719
The change to the import-api was the first step, which was successful. However, the undesired consequence during testing was for larger numbers greater than the original 10-digit limit, requiring larger UTXO values.

We don’t want this. We want to use the alphanumeric code when the length of the integer is longer than 10, when it is 19 digits it is too big for an int value anyway as well, so alphanumeric code needs to be used.

## Changes
- Change pon to bnfp in bnfp validation

