### PR TITLE
Bugfix/massbalance instead of deliverydate

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -838,6 +838,8 @@ def sendToBatchMassBalance_deprecated(batch_raddress, mass_balance_value, integr
 
 
 def sendToBatchMassBalance(batch_raddress, amount, integrity_id):
+    if amount is None:
+        amount = 0.01
     amount = round(amount/1, 10)
     send_batch = sendToBatch(WALLET_MASS_BALANCE, WALLET_MASS_BALANCE_THRESHOLD_UTXO_VALUE, batch_raddress, amount, integrity_id)
     return send_batch # TXID

--- a/openfood.py
+++ b/openfood.py
@@ -839,7 +839,7 @@ def sendToBatchMassBalance_deprecated(batch_raddress, mass_balance_value, integr
 
 def sendToBatchMassBalance(batch_raddress, amount, integrity_id):
     amount = round(amount/1, 10)
-    send_batch = sendToBatch(WALLET_DELIVERY_DATE, WALLET_MASS_BALANCE_THRESHOLD_UTXO_VALUE, batch_raddress, amount, integrity_id)
+    send_batch = sendToBatch(WALLET_MASS_BALANCE, WALLET_MASS_BALANCE_THRESHOLD_UTXO_VALUE, batch_raddress, amount, integrity_id)
     return send_batch # TXID
 
 


### PR DESCRIPTION
## Task

[JC-1763](https://thenewfork.atlassian.net/browse/JC-1763) the bug fix issue



## Related Task (Optional)
[JC-1762](https://thenewfork.atlassian.net/browse/JC-1762) this is the fault, with the workaround in this ticket applied, but a further solution needs to be found for sending 0 value utxos in next sprint.


## Summary
Accepts null, sets a nominal 0.01 value to it.

Sends from correct wallet the correct database field for mass balance.
## Changes
Simple argument passed in correctly.
Check for None and sets value to 0.01

