### PR TITLE
[Main] add openfood_lib_diagnostic.py

### DIFF
--- a/diagnostics/openfood_lib_diagnostics.py
+++ b/diagnostics/openfood_lib_diagnostics.py
@@ -1,0 +1,75 @@
+import os
+import requests
+import json
+
+from openfood_lib_dev.openfood_explorer_lib import explorer_get_network_status
+from openfood_lib_dev.openfood_komodo_node import getinfo
+
+from openfood_lib_dev.openfood_env import IMPORT_API_BASE_URL
+from run import *
+from pprint import pprint
+
+def check_node_status():
+    check_sync()
+    #check_integrity_post_tx_null(limit='')
+    #check_integrity_pre_tx_null(limit='')
+    #check_last_successful_batch(limit='')
+    #get_tx_list()
+
+def check_sync():
+    explorer_get_status = explorer_get_network_status()
+    komodo_info = getinfo()
+
+    komodo_diff = abs(komodo_info['blocks'] - komodo_info['longestchain'])
+    expl_komodo_block_diff = abs(explorer_get_status['info']['blocks'] - komodo_info['blocks'])
+    expl_komodo_chain_diff = abs(explorer_get_status['info']['blocks'] - komodo_info['longestchain'])
+
+    if (komodo_diff == 0 and expl_komodo_block_diff == 0 and expl_komodo_chain_diff == 0):
+        return True
+    else:
+        if (komodo_diff == 1 or expl_komodo_block_diff == 1 or expl_komodo_chain_diff == 1):
+            raise Exception('Try again, only waiting for propagation')
+        elif (komodo_diff > 1 or expl_komodo_block_diff > 1 or expl_komodo_chain_diff > 1):
+            raise Exception('The node could be on a fork. The difference is ' + str(expl_komodo_block_diff) + ':' + str(expl_komodo_chain_diff))
+
+def check_integrity_post_tx_null(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/null-integrity-post-tx/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api integrity_post_tx_null")
+        print(response.text)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check integrity_post_tx is null')
+
+def check_integrity_pre_tx_null(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/null-integrity-pre-tx/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api integrity_pre_tx_null")
+        data = json.loads(response.text)
+        pprint(data)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check integrity_pre_tx is null')
+
+def check_last_successful_batch(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api last_successful_batch")
+        print(response.text)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check last successful batch')
+
+def get_tx_list():
+    print(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/1')
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/1')
+    if response.status_code == 200:
+        print("=== Response from import-api last_successful_batch")
+        data = response.json()
+        if (data['data'][0]['integrity_details'] is None):
+            raise Exception('Integrity details is empty')
+        else:
+            result = data['data'][0]['integrity_details']['tx_list']
+        return result
+    else:
+        raise Exception('Failed to hit import-api to check last successful batch')

--- a/diagnostics/test_diagnostic.py
+++ b/diagnostics/test_diagnostic.py
@@ -1,0 +1,55 @@
+import random
+from openfood_lib_dev.diagnostics.openfood_lib_diagnostics import *
+from openfood_lib_dev import openfood
+from pprint import pprint
+
+def random_int(length):
+	random_int = str(random.randint(1, length))
+	return random_int
+
+def test_check_node_status():
+    NoneType = type(None)
+    try:
+        test = check_node_status()
+        print("Node status is correct")
+        assert isinstance(test, NoneType)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
+def test_check_integrity_pre_tx_null():
+    try:
+        test = check_integrity_pre_tx_null(random_int(1))
+        print("Integrity Pre TX is running well")
+        assert isinstance(test, bool)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
+def test_check_integrity_post_tx_null():
+    try:
+        test = check_integrity_post_tx_null(random_int(1))
+        print("Integrity Post TX is running well")
+        assert isinstance(test, bool)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
+def test_check_last_successful_batch():
+    try:
+        test = check_last_successful_batch(random_int(1))
+        print("Last successful batch is running well")
+        assert isinstance(test, bool)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
+def test_get_tx_list():
+    try:
+        test = get_tx_list()
+        print("Last successful batch to get tx_list is running well")
+        print(test)
+        assert isinstance(test, list)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)

--- a/openfood.py
+++ b/openfood.py
@@ -621,11 +621,13 @@ def sendToBatch(wallet_name, threshold, batch_raddress, amount, integrity_id):
             # log2discord(raw_tx_meta['utxos_slice'])
 
 
-    save_batch_timestamping_tx(integrity_id, wallet_name, wallet['address'], send["txid"])
+    openfood_save_batch_timestamping_tx = save_batch_timestamping_tx(integrity_id, wallet_name, wallet['address'], send["txid"])
+    print(f"openfood_save_batch_timestamping_tx {openfood_save_batch_timestamping_tx}")
     if (send is None):
         print("222 send is none")
         log2discord(f"---\nFailed to send batch: **{batch_raddress}** to **{wallet['address']}**\nAmount sent: **{amount}**\nUTXOs:\n**{utxos_slice}**\n---")
-    return send["txid"]
+    print(type(openfood_save_batch_timestamping_tx))
+    return (send["txid"], json.loads(openfood_save_batch_timestamping_tx))
 
 
 def sendToBatchMassBalance(batch_raddress, amount, integrity_id):
@@ -862,7 +864,7 @@ def postWrapper(url, data):
     if(res.status_code == 200 | res.status_code == 201):
         return res.text
     else:
-        obj = json.dumps({"error": res.reason})
+        obj = json.dumps({"error": res})
         return obj
 
 
@@ -959,7 +961,6 @@ def batch_wallets_timestamping_update(batch_integrity):
 
 def batch_wallets_timestamping_start(batch_integrity, start_txid):
     batch_integrity_url = URL_IMPORT_API_RAW_REFRESCO_INTEGRITY_PATH + batch_integrity['id'] + "/"
-    print(batch_integrity)
     batch_integrity['integrity_pre_tx'] = start_txid
     print(batch_integrity)
     # data = {'name': 'chris', 'integrity_address': integrity_address[

--- a/openfood_explorer_lib.py
+++ b/openfood_explorer_lib.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import os
 
 from .openfood_env import EXPLORER_URL
 from .openfood_komodo_node import decoderawtransaction_wrapper

--- a/openfood_komodo_node.py
+++ b/openfood_komodo_node.py
@@ -352,3 +352,10 @@ def getinfo():
         return get_info
     except Exception as e:
         raise Exception(e)
+
+def listunspent(minconf=1, maxconf=99999, addr=[]):
+    try:
+        txid = rpclib.listunspent(BATCHRPC, minconf, maxconf, addr)
+        return txid
+    except Exception as e:
+        sentry_sdk.capture_message(str(e), 'warning')

--- a/openfood_komodo_node.py
+++ b/openfood_komodo_node.py
@@ -219,14 +219,15 @@ def decoderawtransaction_wrapper(rawtx):
 def check_sync():
     try:
         general_info = rpclib.getinfo(BATCHRPC)
+        #print(f" general_info {general_info}")
         sync = general_info['longestchain'] - general_info['blocks']
 
         print("Chain info.  Longest chain, blocks, sync diff")
-        print(general_info['longestchain'])
+        print(f"Longest chain {general_info['longestchain']}")
 
-        print(general_info['blocks'])
+        print(f"General info {general_info['blocks']}")
 
-        print(sync)
+        print(f"Sync {sync}")
 
         if sync >= BLOCKNOTIFY_CHAINSYNC_LIMIT:
             print('the chain is not synced, try again later')
@@ -253,7 +254,7 @@ def check_node_wallet():
         return is_mine
     except Exception as e:
         sentry_sdk.capture_message(str(e), 'warning')
-        print(e)
+        print(str(e))
         print("## CHECK NODE WALLET ERROR ##")
         print("# Things that could be wrong:")
         print("# Wallet is not imported on this node or wallet mismatch to env")
@@ -278,7 +279,7 @@ def check_kv1_wallet():
         return is_mine
     except Exception as e:
         sentry_sdk.capture_message(str(e), 'warning')
-        print(e)
+        print(str(e))
         print("## CHECK KV1 WALLET ERROR ##")
         print("# Things that could be wrong:")
         print("# Wallet is not imported on this node or wallet mismatch to env")

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -6,7 +6,8 @@ from openfood_lib_dev.openfood_explorer_lib import explorer_get_network_status
 from openfood_lib_dev.openfood_komodo_node import getinfo
 
 from openfood_lib_dev.openfood_env import IMPORT_API_BASE_URL
-
+from run import *
+from pprint import pprint
 
 def check_node_status():
     check_sync()
@@ -44,7 +45,8 @@ def check_integrity_pre_tx_null(limit):
     response = requests.get(IMPORT_API_BASE_URL + 'batch/import/null-integrity-pre-tx/limit/' + str(limit))
     if response.status_code == 200:
         print("=== Response from import-api integrity_pre_tx_null")
-        print(response.text)
+        data = json.loads(response.text)
+        pprint(data)
         return True
     else:
         raise Exception('Failed to hit import-api to check integrity_pre_tx is null')

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -10,6 +10,7 @@ from openfood_lib_dev.openfood_env import IMPORT_API_BASE_URL
 def check_node_status():
     check_sync()
     check_integrity_post_tx_null(limit='')
+    check_last_successful_batch(limit='')
 
 def check_sync():
     explorer_get_status = explorer_get_network_status()
@@ -35,3 +36,12 @@ def check_integrity_post_tx_null(limit):
         return True
     else:
         raise Exception('Failed to hit import-api to check integrity_post_tx is null')
+
+def check_last_successful_batch(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api last_successful_batch")
+        print(response.text)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check last successful batch')

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -11,7 +11,9 @@ from openfood_lib_dev.openfood_env import IMPORT_API_BASE_URL
 def check_node_status():
     check_sync()
     check_integrity_post_tx_null(limit='')
+    check_integrity_pre_tx_null(limit='')
     check_last_successful_batch(limit='')
+    get_tx_list()
 
 def check_sync():
     explorer_get_status = explorer_get_network_status()
@@ -37,6 +39,15 @@ def check_integrity_post_tx_null(limit):
         return True
     else:
         raise Exception('Failed to hit import-api to check integrity_post_tx is null')
+
+def check_integrity_pre_tx_null(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/null-integrity-pre-tx/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api integrity_pre_tx_null")
+        print(response.text)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check integrity_pre_tx is null')
 
 def check_last_successful_batch(limit):
     response = requests.get(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/' + str(limit))

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -1,0 +1,21 @@
+from openfood_lib_dev.openfood_explorer_lib import explorer_get_network_status
+from openfood_lib_dev.openfood_komodo_node import getinfo
+
+def check_node_status():
+    check_sync()
+
+def check_sync():
+    explorer_get_status = explorer_get_network_status()
+    komodo_info = getinfo()
+
+    komodo_diff = abs(komodo_info['blocks'] - komodo_info['longestchain'])
+    expl_komodo_block_diff = abs(explorer_get_status['info']['blocks'] - komodo_info['blocks'])
+    expl_komodo_chain_diff = abs(explorer_get_status['info']['blocks'] - komodo_info['longestchain'])
+
+    if (komodo_diff == 0 and expl_komodo_block_diff == 0 and expl_komodo_chain_diff == 0):
+        return True
+    else:
+        if (komodo_diff == 1 or expl_komodo_block_diff == 1 or expl_komodo_chain_diff == 1):
+            raise Exception('Try again, only waiting for propagation')
+        elif (komodo_diff > 1 or expl_komodo_block_diff > 1 or expl_komodo_chain_diff > 1):
+            raise Exception('The node could be on a fork. The difference is ' + str(expl_komodo_block_diff) + ':' + str(expl_komodo_chain_diff))

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -1,8 +1,15 @@
+import os
+import requests
+
 from openfood_lib_dev.openfood_explorer_lib import explorer_get_network_status
 from openfood_lib_dev.openfood_komodo_node import getinfo
 
+from openfood_lib_dev.openfood_env import IMPORT_API_BASE_URL
+
+
 def check_node_status():
     check_sync()
+    check_integrity_post_tx_null(limit='')
 
 def check_sync():
     explorer_get_status = explorer_get_network_status()
@@ -19,3 +26,12 @@ def check_sync():
             raise Exception('Try again, only waiting for propagation')
         elif (komodo_diff > 1 or expl_komodo_block_diff > 1 or expl_komodo_chain_diff > 1):
             raise Exception('The node could be on a fork. The difference is ' + str(expl_komodo_block_diff) + ':' + str(expl_komodo_chain_diff))
+
+def check_integrity_post_tx_null(limit):
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/null-integrity-post-tx/limit/' + str(limit))
+    if response.status_code == 200:
+        print("=== Response from import-api integrity_post_tx_null")
+        print(response.text)
+        return True
+    else:
+        raise Exception('Failed to hit import-api to check integrity_post_tx is null')

--- a/openfood_lib_diagnostics.py
+++ b/openfood_lib_diagnostics.py
@@ -1,5 +1,6 @@
 import os
 import requests
+import json
 
 from openfood_lib_dev.openfood_explorer_lib import explorer_get_network_status
 from openfood_lib_dev.openfood_komodo_node import getinfo
@@ -43,5 +44,19 @@ def check_last_successful_batch(limit):
         print("=== Response from import-api last_successful_batch")
         print(response.text)
         return True
+    else:
+        raise Exception('Failed to hit import-api to check last successful batch')
+
+def get_tx_list():
+    print(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/1')
+    response = requests.get(IMPORT_API_BASE_URL + 'batch/import/last-successful-batch/limit/1')
+    if response.status_code == 200:
+        print("=== Response from import-api last_successful_batch")
+        data = response.json()
+        if (data['data'][0]['integrity_details'] is None):
+            raise Exception('Integrity details is empty')
+        else:
+            result = data['data'][0]['integrity_details']['tx_list']
+        return result
     else:
         raise Exception('Failed to hit import-api to check last successful batch')

--- a/rpclib.py
+++ b/rpclib.py
@@ -131,6 +131,13 @@ def createrawtransaction_addr_amount_dict(rpc_connection, txids_vouts, address_a
     except Exception as e:
         raise Exception(e)
     return rawtransaction
+
+def listunspent(rpc_connection, minconf, maxconf, addr):
+    try:
+        listunspent = rpc_connection.listunspent(minconf, maxconf, addr)
+    except Exception as e:
+        raise Exception(str(e))
+    return listunspent
 """END - New function for address_amount_dict"""
 
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,7 @@
 import random
 from openfood_lib_dev.openfood_lib_diagnostics import *
+from openfood_lib_dev import openfood
+from pprint import pprint
 
 def random_int(length):
 	random_int = str(random.randint(1, length))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -32,3 +32,13 @@ def test_check_last_successful_batch():
     except Exception as ex:
         print(str(ex))
         assert isinstance(str(ex), str)
+
+def test_get_tx_list():
+    try:
+        test = get_tx_list()
+        print("Last successful batch to get tx_list is running well")
+        print(test)
+        assert isinstance(test, list)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,5 +1,9 @@
-#from types import NoneType
+import random
 from openfood_lib_dev.openfood_lib_diagnostics import *
+
+def random_int(length):
+	random_int = str(random.randint(1, length))
+	return random_int
 
 def test_check_node_status():
     NoneType = type(None)
@@ -13,7 +17,7 @@ def test_check_node_status():
 
 def test_check_integrity_post_tx_null():
     try:
-        test = check_integrity_post_tx_null(2)
+        test = check_integrity_post_tx_null(random_int(1))
         print("Integrity Post TX is running well")
         assert isinstance(test, bool)
     except Exception as ex:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -15,6 +15,15 @@ def test_check_node_status():
         print(str(ex))
         assert isinstance(str(ex), str)
 
+def test_check_integrity_pre_tx_null():
+    try:
+        test = check_integrity_pre_tx_null(random_int(1))
+        print("Integrity Pre TX is running well")
+        assert isinstance(test, bool)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
 def test_check_integrity_post_tx_null():
     try:
         test = check_integrity_post_tx_null(random_int(1))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -23,3 +23,12 @@ def test_check_integrity_post_tx_null():
     except Exception as ex:
         print(str(ex))
         assert isinstance(str(ex), str)
+
+def test_check_last_successful_batch():
+    try:
+        test = check_last_successful_batch(random_int(1))
+        print("Last successful batch is running well")
+        assert isinstance(test, bool)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,3 +1,4 @@
+#from types import NoneType
 from openfood_lib_dev.openfood_lib_diagnostics import *
 
 def test_check_node_status():
@@ -6,6 +7,15 @@ def test_check_node_status():
         test = check_node_status()
         print("Node status is correct")
         assert isinstance(test, NoneType)
+    except Exception as ex:
+        print(str(ex))
+        assert isinstance(str(ex), str)
+
+def test_check_integrity_post_tx_null():
+    try:
+        test = check_integrity_post_tx_null(2)
+        print("Integrity Post TX is running well")
+        assert isinstance(test, bool)
     except Exception as ex:
         print(str(ex))
         assert isinstance(str(ex), str)

--- a/tests/test_komodo_node.py
+++ b/tests/test_komodo_node.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import requests
 from typing import List, Tuple, Dict
+from pprint import pprint
 
 from openfood_lib_dev import openfood
 from openfood_lib_dev.openfood_komodo_node import *
@@ -17,6 +18,6 @@ def test_get_info():
 def test_list_unspent():
     batch_chain = openfood.connect_batch_node()
 
-    addr = ["RH5dNSsN3k4wfHZ2zbNBqtAQ9hJyVJWy4r"]
+    addr = ["RAwfTfrfX1WroXgZpQWPRsSNoV8e4gS6qs"]
     response = listunspent(1, 99999, addr)
     assert isinstance(response, list)

--- a/tests/test_komodo_node.py
+++ b/tests/test_komodo_node.py
@@ -1,7 +1,10 @@
+import os
 import pytest
 import requests
+from typing import List, Tuple, Dict
 
-from openfood_lib_dev.openfood_komodo_node import getbalance, getinfo
+from openfood_lib_dev import openfood
+from openfood_lib_dev.openfood_komodo_node import *
 
 def test_get_balance():
     response = getbalance()
@@ -10,3 +13,10 @@ def test_get_balance():
 def test_get_info():
     response = getinfo()
     assert isinstance(response, dict)
+
+def test_list_unspent():
+    batch_chain = openfood.connect_batch_node()
+
+    addr = ["RH5dNSsN3k4wfHZ2zbNBqtAQ9hJyVJWy4r"]
+    response = listunspent(1, 99999, addr)
+    assert isinstance(response, list)


### PR DESCRIPTION
## Task
[JC-1923](https://thenewfork.atlassian.net/browse/JC-1923)
[JC-1922](https://thenewfork.atlassian.net/browse/JC-1922)
[JC-1911](https://thenewfork.atlassian.net/browse/JC-1911)
[JC-1919](https://thenewfork.atlassian.net/browse/JC-1919)
[JC-1972](https://thenewfork.atlassian.net/browse/JC-1972)

## Related Task
[#56](https://github.com/The-New-Fork/import-api/pull/56) (import-api)
[#57](https://github.com/The-New-Fork/import-api/pull/57) (import-api)
[#86](https://github.com/The-New-Fork/blocknotify-python/pull/86) (blocknotify-python)

## Depends On (Optional)
[JC-1907](https://thenewfork.atlassian.net/browse/JC-1907)

## Summary
- add openfood_lib_diagnostic library
- import-api filter by batches with integrity_post_tx null
- import-api get last_successful_batch
- import-api get tx_list from batch
- add integrity_pre_tx null
- add lib_unspent function to diagnostic
- add batch next expected data spend

## Changes
- add openfood_lib_diagnostic library
- import-api filter by batches with integrity_post_tx null
- import-api get last_successful_batch
- import-api get tx_list from batch
- add integrity_pre_tx null
- add lib_unspent function to diagnostic
- add batch next expected data spend

## Others (Optional)
How to run test:
- Go to **test folder** (/deploy-samples/simple-working/organization/blocknotify-python/openfood_lib_dev/tests)
- run command **pytest -s test_diagnostics.py**