### PR TITLE
product_id attr added to json for pushing to juicychain-api

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -1180,6 +1180,7 @@ def restart_offline_wallet_sent(integrity_id):
 
 def push_batch_data_consumer(jcapi_org_id, batch, batch_wallet):
         data = {'identifier': batch['bnfp'],
+                'product_id': batch['anfp'],
                 'jds': batch['jds'],
                 'jde': batch['jde'],
                 'date_production_start': batch['pds'],


### PR DESCRIPTION
## Task
[JC-2111](https://thenewfork.atlassian.net/browse/JC-2111)

## Related Task (Optional)
[JC-2113](https://thenewfork.atlassian.net/browse/JC-2113) epic.

## Depends On (Optional)
Pushes to the changes in juicychain-api made in the-new-fork/juicychain-api#48 & the-new-fork/juicychain-api#49

## Summary
When pushing to juicychain-api the batch data for product id (anfp) needs to be pushed to juicychain-api so @An Nisa Santi is able to continue with work on this epic [JC-2113: Multiple juice supportTO DO](https://thenewfork.atlassian.net/browse/JC-2113) starting with [JC-2117: GUI - Page - Unclaimed batches with no matching product idTO DO](https://thenewfork.atlassian.net/browse/JC-2117) and [JC-2114: GUI - Page - Create ProductTO DO](https://thenewfork.atlassian.net/browse/JC-2114).

## Changes
Adds product_id attribute to json object that is pushed to juicychain-api
