### PR TITLE
fixes JC-2166 tidy log statement

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -1068,7 +1068,7 @@ def organization_send_batch_links3(batch_integrity, pon, bnfp):
     pool_po = organization_get_our_pool_po_wallet()
     customer_pool_wallet = organization_get_customer_po_wallet(CUSTOMER_RADDRESS)
 
-    print("****** MAIN WALLET batch links sendmany ******* " + THIS_NODE_RADDRESS)
+    print("****** MAIN WALLET batch links sendmany from ******* " + THIS_NODE_RADDRESS)
     print(pool_batch_wallet)
     print("CUSTOMER POOL WALLET: " + customer_pool_wallet)
 


### PR DESCRIPTION
## Task
[JC-2166](https://thenewfork.atlassian.net/browse/JC-2166)


## Summary
Adds the word `from` to make it clear which wallet is sending batch links.