### PR TITLE
JC-2652 Bugfix/get jcapi fraddress

### DIFF
--- a/openfood.py
+++ b/openfood.py
@@ -178,6 +178,11 @@ def format_oracle_data_bytes_gt256(data):
     raise Exception("257 to 9000 bytes not supported yet, need length in 2 bytes little endian")
 
 
+def foundation_publish_pool_wallets():
+    pool_wallets = generate_pool_wallets()
+    pass
+
+
 # test skipped
 def get_this_node_raddress():
     return THIS_NODE_RADDRESS
@@ -1168,9 +1173,9 @@ def get_jcapi_organization():
     return organizations
 
 
-def get_jcapi_foundation():
-    print("GET openfood-api foundation query: " + URL_openfood_API_FOUNDATION + "?raddress=" + THIS_NODE_RADDRESS)
-    res = getWrapper(URL_openfood_API_FOUNDATION + "?raddress=" + THIS_NODE_RADDRESS)
+def get_jcapi_foundation(foundation_raddress):
+    print(f"GET openfood-api foundation query: {URL_openfood_API_FOUNDATION}?raddress={foundation_raddress}")
+    res = getWrapper(f"{URL_openfood_API_FOUNDATION}?raddress={foundation_raddress}")
     foundation_res = json.loads(res)
     if len(foundation_res) == 0:
         return foundation_res

--- a/openfood.py
+++ b/openfood.py
@@ -266,7 +266,7 @@ def get_foundation_oracleid():
     if BYPASS_ORACLE:
         return mock_txid()
     # from API
-    oracle_get_res = get_jcapi_foundation_oracle(get_jcapi_foundation(get_foundation_raddress()))
+    oracle_get_res = get_jcapi_foundation_oracle(get_jcapi_foundation(get_foundation_raddress())['id'])
     return oracle_get_res['oracle_txid']
     # from chain
     # oracletxid = find_oracleid_with_pubkey(get_foundation_pubkey())


### PR DESCRIPTION
## Task
[JC-2652](https://thenewfork.atlassian.net/browse/JC-2652)

## Summary
Fixes argument passing from organization to lookup foundation info (id) to get oracle info.

[JC-2652]: https://thenewfork.atlassian.net/browse/JC-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ